### PR TITLE
5 support restore from the latest backup

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -14,7 +14,9 @@ if [ $# -eq 1 ]; then
     BACKUP_FILE="$1"
 else
     echo "No backup file specified, getting latest backup..."
-    BACKUP_FILE=$(rclone lsf --format "tp" --include "*.sql.gz" "remote:${BUCKET_NAME}" | sort -nrk1 | head -1 | awk '{print $2}')
+
+    BACKUP_FILE=$(rclone lsl remote:${BUCKET_NAME} --order-by modtime,desc | head -n 1 | awk '{print $NF}')
+
     if [ -z "$BACKUP_FILE" ]; then
         echo "ERROR: No backup files found in remote:${BUCKET_NAME}" >&2
         exit 1

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -15,8 +15,8 @@ if [ $# -eq 1 ]; then
 else
     echo "No backup file specified, getting latest backup..."
 
-    # List files ordered by time, newest first, and get just the filename
-    BACKUP_FILE=$(rclone lsf remote:${BUCKET_NAME} --order-by modtime,desc --format p | head -n 1)
+    # List files, filter for postgres backup files, sort by filename, and get the newest
+    BACKUP_FILE=$(rclone lsf remote:${BUCKET_NAME} | grep -E '^postgres-.*\.sql\.gz$' | sort -r | head -n 1)
 
     if [ -z "$BACKUP_FILE" ]; then
         echo "ERROR: No backup files found in remote:${BUCKET_NAME}" >&2

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-BACKUP_FILE="$1"
-
 # Default values
 : "${POSTGRES_HOST:=localhost}"
 : "${POSTGRES_PORT:=5432}"
@@ -11,6 +9,17 @@ BACKUP_FILE="$1"
 : "${POSTGRES_DB:=postgres}"
 : "${BUCKET_NAME:=backups}"
 
+# Get backup file from argument or use latest
+if [ $# -eq 1 ]; then
+    BACKUP_FILE="$1"
+else
+    echo "No backup file specified, getting latest backup..."
+    BACKUP_FILE=$(rclone lsf --format "tp" --include "*.sql.gz" "remote:${BUCKET_NAME}" | sort -nrk1 | head -1 | awk '{print $2}')
+    if [ -z "$BACKUP_FILE" ]; then
+        echo "ERROR: No backup files found in remote:${BUCKET_NAME}" >&2
+        exit 1
+    fi
+fi
 
 # Check if backup exists in S3
 echo "Checking if backup exists: remote:${BUCKET_NAME}/${BACKUP_FILE}"
@@ -30,9 +39,7 @@ echo "Starting PostgreSQL restore process..."
 
 # Stream restore directly from S3 to PostgreSQL
 echo "Restoring ${BACKUP_FILE} to database ${POSTGRES_DB}"
-if ! rclone cat "remote:${BUCKET_NAME}/${BACKUP_FILE}" | \
-     gunzip | \
-     PGPASSWORD="${POSTGRES_PASSWORD:-}" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; then
+if ! rclone cat "remote:${BUCKET_NAME}/${BACKUP_FILE}" |      gunzip |      PGPASSWORD="${POSTGRES_PASSWORD:-}" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; then
     echo "ERROR: Restore failed" >&2
     exit 1
 fi

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -92,5 +92,5 @@ EOF
   # Verify the latest data exists (we should have at least 2 rows)
   run docker compose exec -T postgres psql -U postgres -tAc "SELECT COUNT(*) FROM test_data"
   assert_success
-  assert [ "$output" -ge 1 ]  # More conservative check - we should have at least 1 row
+  assert_equal $output  2
 }

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -64,6 +64,7 @@ EOF
   docker compose exec -T postgres psql -U postgres -c "INSERT INTO test_data VALUES (DEFAULT)"
 
   # Get timestamp before creating our "latest" backup
+  docker compose run --rm backup backup.sh
   current_time=$(date +%s)
   sleep 2  # Make sure the next backup will have a different timestamp
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -58,8 +58,7 @@ EOF
 
 @test "Restore from latest backup works correctly without filename" {
   # Drop and recreate test table to start fresh
-  docker compose exec -T postgres psql -U postgres -c "DROP TABLE IF EXISTS test_data"
-  docker compose exec -T postgres psql -U postgres -c "CREATE TABLE test_data (id SERIAL PRIMARY KEY)"
+  docker compose exec -T postgres psql -U postgres -c "DROP TABLE IF EXISTS test_data; CREATE TABLE test_data (id SERIAL PRIMARY KEY)"
 
   # Create first backup with initial data
   docker compose exec -T postgres psql -U postgres -c "INSERT INTO test_data VALUES (DEFAULT)"


### PR DESCRIPTION
This pull request updates the `restore.sh` script to handle cases where no backup file is specified and adds a new integration test to verify this functionality. The most important changes include modifying the script to automatically select the latest backup file if none is provided and adding a corresponding test case.

Changes to `restore.sh`:

* Added logic to determine the latest backup file if no filename is provided as an argument.
* Simplified the restore command by combining multiple lines into one.

Changes to integration tests:

* Updated the test case for restoring from a backup to specify the filename explicitly.
* Added a new test case to verify that restoring from the latest backup works correctly when no filename is provided.